### PR TITLE
don't run Nightly if this is a forked repo

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,6 +12,8 @@ permissions:
   contents: write
 jobs:
   nightly-electron:
+    # don't run if this is a forked repo
+    if: github.repository == 'TriliumNext/Notes'
     name: Deploy nightly    
     strategy:
       fail-fast: false


### PR DESCRIPTION
Only run the Nightly Release action from the main org repo. Otherwise every fork will try and run this action, wasting resources and spamming with fail messages.

Unfortunately untested, because I can't from a fork ;-)

adapted from https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository